### PR TITLE
Fix sixer

### DIFF
--- a/src/EMCTasker.py
+++ b/src/EMCTasker.py
@@ -157,7 +157,7 @@ class EMCExecutioner:
 			emcDebugOut("[emcTasker] runFinished exception:\n" + str(e))
 
 	def dataAvail(self, string):
-		self.returnData += "\n" + "\n".replace("")
+		self.returnData += "\n" + string.replace("\n", "")
 
 
 class EMCTasker:


### PR DESCRIPTION
Reported by HD75hd
```
2021-09-02 18:22:38+0200 [-] Traceback (most recent call last):
2021-09-02 18:22:38+0200 [-]   File "/usr/lib/enigma2/python/Plugins/Extensions/EnhancedMovieCenter/EMCTasker.py", line 160, in dataAvail
2021-09-02 18:22:38+0200 [-]     self.returnData += "\n" + "\n".replace("")
2021-09-02 18:22:38+0200 [-] TypeError: replace expected at least 2 arguments, got 1
[ePyObject] (PyObject_CallObject(<bound method EMCExecutioner.dataAvail of <Plugins.Extensions.EnhancedMovieCenter.EMCTasker.EMCExecutioner object at 0xb3480ee0>>,(b"mv: can't rename '/media/hdd/movie/trashcan': Invalid argument\n",)) failed)
```