### PR TITLE
Extension of the support for further encodings according to the specification ETSI EN 300 468

### DIFF
--- a/src/EitSupport.py
+++ b/src/EitSupport.py
@@ -68,6 +68,138 @@ def language_iso639_2to3(alpha2):
 					return alpha
 	return ret
 
+
+def _ord(val):
+	if six.PY3:
+		return val
+	else:
+		return ord(val)
+
+
+# Convert string to bytes without encoding
+def encode_binary(input):
+    output = bytes([ord(char) for char in input])
+    return output
+
+
+# Get encoding
+def getEventEncoding(data):
+	encoding = None
+	try:
+		if len(data) > 0:
+			byte1 = _ord(data[0])			
+			if byte1 == 0x01:
+				encoding = 'iso-8859-5'
+			elif byte1 == 0x02:
+				encoding = 'iso-8859-6'
+			elif byte1 == 0x03:
+				encoding = 'iso-8859-7'
+			elif byte1 == 0x04:
+				encoding = 'iso-8859-8'
+			elif byte1 == 0x05:
+				encoding = 'iso-8859-9'
+			elif byte1 == 0x06:
+				encoding = 'iso-8859-10'
+			elif byte1 == 0x07:
+				encoding = 'iso-8859-11'
+			elif byte1 == 0x09:
+				encoding = 'iso-8859-13'
+			elif byte1 == 0x0A:
+				encoding = 'iso-8859-14'
+			elif byte1 == 0x0B:
+				encoding = 'iso-8859-15'
+			elif byte1 == 0x15:
+				encoding = 'utf-8'
+			elif byte1 == 0x10 and len(data) > 2:
+				byte2 = _ord(data[1])
+				if byte2 == 0x00:
+					byte3 = _ord(data[2])
+					if byte3 == 0x01:
+						encoding = 'iso-8859-1'
+					elif byte3 == 0x02:
+						encoding = 'iso-8859-2'
+					elif byte3 == 0x03:
+						encoding = 'iso-8859-3'
+					elif byte3 == 0x04:
+						encoding = 'iso-8859-4'
+					elif byte3 == 0x05:
+						encoding = 'iso-8859-5'
+					elif byte3 == 0x06:
+						encoding = 'iso-8859-6'
+					elif byte3 == 0x07:
+						encoding = 'iso-8859-7'
+					elif byte3 == 0x08:
+						encoding = 'iso-8859-8'
+					elif byte3 == 0x09:
+						encoding = 'iso-8859-9'
+					elif byte3 == 0x0A:
+						encoding = 'iso-8859-10'
+					elif byte3 == 0x0B:
+						encoding = 'iso-8859-11'
+					elif byte3 == 0x0D:
+						encoding = 'iso-8859-13'
+					elif byte3 == 0x0E:
+						encoding = 'iso-8859-14'
+					elif byte3 == 0x0F:
+						encoding = 'iso-8859-15'			
+			elif byte1 >= 0x20 and byte1 <= 0xFF:
+				encoding = 'iso6937'
+			#elif byte1 >= 0x11 and byte <= 0x14:	### not supported now
+			#	encoding = None
+	except:
+		encoding = None
+	return encoding
+
+
+# Read event data and decode it
+def readEventData(data, index, name):
+	description = ""
+	length = _ord(data[index])
+	if length > 0:
+		encoding = getEventEncoding(data[index + 1:index + 4])
+		if encoding:
+			emcDebugOut("[META] Found " + name + " encoding-type: " + encoding)			
+		for i in list(range(index + 1, index + length + 1)):
+			try:
+				if _ord(data[i]) == 0x0A or _ord(data[i]) > 0x1F:
+					if six.PY3:
+						description += chr(data[i])
+					else:
+						description += data[i]
+			except IndexError as e:
+				emcDebugOut("[META] Exception in readEitFile: " + str(e))
+
+		if description:
+			try:
+				if encoding:
+					if encoding != 'iso6937':
+						if six.PY3:
+							description = encode_binary(description).decode(encoding)
+						elif encoding != 'utf-8':
+							description = description.decode(encoding).encode("utf-8")
+					elif not six.PY3:
+						description = description.decode('cp1252').encode("utf-8")
+				else:
+					description = encode_binary(description)
+					encdata = chardet.detect(description)
+					enc = encdata['encoding'].lower()
+					confidence = str(encdata['confidence'])
+					emcDebugOut("[META] Detected " + name + " encoding-type: " + enc + " (" + confidence + ")")
+					description = six.ensure_str(description, enc)
+			except (UnicodeDecodeError, AttributeError) as e:
+				emcDebugOut("[META] Exception in readEitFile: " + str(e))
+	return length + 1, description
+
+
+def addDescriptionToList(description, descriptionList, pluginLanguage, eventLanguage, prevEventLanguage, newLine = True):
+	if eventLanguage == pluginLanguage:
+		descriptionList[0].append(description)
+	if (eventLanguage == prevEventLanguage) or (prevEventLanguage == "x"):
+		descriptionList[1].append(description)
+	else:
+		descriptionList[1].append("\n\n" if newLine else "  " + description)
+
+
 # Eit File support class
 # Description
 # http://de.wikipedia.org/wiki/Event_Information_Table
@@ -181,14 +313,6 @@ class EitList():
 
 		lang = (language_iso639_2to3(config.EMC.epglang.value.lower()[:2])).upper()
 
-		PY3 = sys.version_info[0] == 3
-
-		def _ord(val):
-			if PY3:
-				return val
-			else:
-				return ord(val)
-
 		if path and os.path.exists(path):
 			mtime = os.path.getmtime(path)
 			if self.eit_mtime == mtime:
@@ -238,15 +362,10 @@ class EitList():
 					self.eit['duration'] = duration
 
 					pos = pos + 12
-					name_event_descriptor = []
-					name_event_descriptor_multi = []
-					name_event_codepage = None
-					short_event_descriptor = []
-					short_event_descriptor_multi = []
-					short_event_codepage = None
-					extended_event_descriptor = []
-					extended_event_descriptor_multi = []
-					extended_event_codepage = None
+					name_event_descriptors = [ [], [] ]
+					short_event_descriptors = [ [], [] ]
+					extended_event_descriptors = [ [], [] ]
+					extended_event_items = [ [], [] ]
 					component_descriptor = []
 					content_descriptor = []
 					linkage_descriptor = []
@@ -259,157 +378,54 @@ class EitList():
 						if pos + 1 >= endpos:
 							break
 						length = _ord(data[pos + 1]) + 2
+						idx = pos
 						#if pos+length>=endpos:
 						#	break
 						if rec == 0x4D:
-							descriptor_tag = _ord(data[pos + 1])
-							descriptor_length = _ord(data[pos + 2])
-							ISO_639_language_code = six.ensure_str(data[pos + 2:pos + 5]).upper()
-							event_name_length = _ord(data[pos + 5])
-							name_event_description = ""
-							for i in list(range(pos + 6, pos + 6 + event_name_length)):
-								try:
-									if PY3:
-										if data[i] == 10 or data[i] > 31:
-											name_event_description += chr(data[i])
-									else:
-										if str(_ord(data[i])) == "10" or int(str(_ord(data[i]))) > 31:
-											name_event_description += data[i]
-								except IndexError as e:
-									emcDebugOut("[META] Exception in readEitFile: " + str(e))
-							if not name_event_codepage:
-								try:
-									byte1 = str(_ord(data[pos + 6]))
-								except:
-									byte1 = ''
-								if byte1 == "1":
-									name_event_codepage = 'iso-8859-5'
-								elif byte1 == "2":
-									name_event_codepage = 'iso-8859-6'
-								elif byte1 == "3":
-									name_event_codepage = 'iso-8859-7'
-								elif byte1 == "4":
-									name_event_codepage = 'iso-8859-8'
-								elif byte1 == "5":
-									name_event_codepage = 'iso-8859-9'
-								elif byte1 == "6":
-									name_event_codepage = 'iso-8859-10'
-								elif byte1 == "7":
-									name_event_codepage = 'iso-8859-11'
-								elif byte1 == "9":
-									name_event_codepage = 'iso-8859-13'
-								elif byte1 == "10":
-									name_event_codepage = 'iso-8859-14'
-								elif byte1 == "11":
-									name_event_codepage = 'iso-8859-15'
-								elif byte1 == "21":
-									name_event_codepage = 'utf-8'
-								if name_event_codepage:
-									emcDebugOut("[META] Found name_event encoding-type: " + name_event_codepage)
-							short_event_description = ""
-							if not short_event_codepage:
-								try:
-									byte1 = str(_ord(data[pos + 7 + event_name_length]))
-								except:
-									byte1 = ''
-								if byte1 == "1":
-									short_event_codepage = 'iso-8859-5'
-								elif byte1 == "2":
-									short_event_codepage = 'iso-8859-6'
-								elif byte1 == "3":
-									short_event_codepage = 'iso-8859-7'
-								elif byte1 == "4":
-									short_event_codepage = 'iso-8859-8'
-								elif byte1 == "5":
-									short_event_codepage = 'iso-8859-9'
-								elif byte1 == "6":
-									short_event_codepage = 'iso-8859-10'
-								elif byte1 == "7":
-									short_event_codepage = 'iso-8859-11'
-								elif byte1 == "9":
-									short_event_codepage = 'iso-8859-13'
-								elif byte1 == "10":
-									short_event_codepage = 'iso-8859-14'
-								elif byte1 == "11":
-									short_event_codepage = 'iso-8859-15'
-								elif byte1 == "21":
-									short_event_codepage = 'utf-8'
-								if short_event_codepage:
-									emcDebugOut("[META] Found short_event encoding-type: " + short_event_codepage)
-							for i in list(range(pos + 7 + event_name_length, pos + length)):
-								try:
-									if PY3:
-										if data[i] == 10 or data[i] > 31:
-											short_event_description += chr(data[i])
-									else:
-										if str(_ord(data[i])) == "10" or int(str(_ord(data[i]))) > 31:
-											short_event_description += data[i]
-								except IndexError as e:
-									emcDebugOut("[META] Exception in readEitFile: " + str(e))
-							if ISO_639_language_code == lang:
-								short_event_descriptor.append(short_event_description)
-								name_event_descriptor.append(name_event_description)
-							if (ISO_639_language_code == prev1_ISO_639_language_code) or (prev1_ISO_639_language_code == "x"):
-								short_event_descriptor_multi.append(short_event_description)
-								name_event_descriptor_multi.append(name_event_description)
-							else:
-								short_event_descriptor_multi.append("\n\n" + short_event_description)
-								name_event_descriptor_multi.append(" " + name_event_description)
-							prev1_ISO_639_language_code = ISO_639_language_code
+							ISO_639_language_code = six.ensure_str(data[idx + 2:idx + 5]).upper()
+							idx += 5
+
+							### section name
+							(offset, name_event_description) = readEventData(data, idx, "name_event")
+							if offset > 0:
+								addDescriptionToList(name_event_description, name_event_descriptors, lang, ISO_639_language_code, prev1_ISO_639_language_code, False)
+							idx += offset
+							
+							### section description
+							(offset, short_event_description) = readEventData(data, idx, "short_event")
+							if offset > 0:
+								addDescriptionToList(short_event_description, short_event_descriptors, lang, ISO_639_language_code, prev1_ISO_639_language_code)
+
+							prev1_ISO_639_language_code = ISO_639_language_code							
 						elif rec == 0x4E:
-							ISO_639_language_code = ""
-							for i in list(range(pos + 3, pos + 6)):
-								if PY3:
-									ISO_639_language_code += str(data[i])
-								else:
-									ISO_639_language_code += data[i]
-							ISO_639_language_code = ISO_639_language_code.upper()
-							extended_event_description = ""
-							if not extended_event_codepage:
-								try:
-									byte1 = str(_ord(data[pos + 8]))
-								except:
-									byte1 = ''
-								if byte1 == "1":
-									extended_event_codepage = 'iso-8859-5'
-								elif byte1 == "2":
-									extended_event_codepage = 'iso-8859-6'
-								elif byte1 == "3":
-									extended_event_codepage = 'iso-8859-7'
-								elif byte1 == "4":
-									extended_event_codepage = 'iso-8859-8'
-								elif byte1 == "5":
-									extended_event_codepage = 'iso-8859-9'
-								elif byte1 == "6":
-									extended_event_codepage = 'iso-8859-10'
-								elif byte1 == "7":
-									extended_event_codepage = 'iso-8859-11'
-								elif byte1 == "9":
-									extended_event_codepage = 'iso-8859-13'
-								elif byte1 == "10":
-									extended_event_codepage = 'iso-8859-14'
-								elif byte1 == "11":
-									extended_event_codepage = 'iso-8859-15'
-								elif byte1 == "21":
-									extended_event_codepage = 'utf-8'
-								if extended_event_codepage:
-									emcDebugOut("[META] Found extended_event encoding-type: " + extended_event_codepage)
-							for i in list(range(pos + 8, pos + length)):
-								try:
-									if PY3:
-										if data[i] == 10 or data[i] > 31:
-											extended_event_description += chr(data[i])
-									else:
-										if str(_ord(data[i])) == "10" or int(str(_ord(data[i]))) > 31:
-											extended_event_description += data[i]
-								except IndexError as e:
-									emcDebugOut("[META] Exception in readEitFile: " + str(e))
-							if ISO_639_language_code == lang:
-								extended_event_descriptor.append(extended_event_description)
-							if (ISO_639_language_code == prev2_ISO_639_language_code) or (prev2_ISO_639_language_code == "x"):
-								extended_event_descriptor_multi.append(extended_event_description)
-							else:
-								extended_event_descriptor_multi.append("\n\n" + extended_event_description)
+							ISO_639_language_code = six.ensure_str(data[idx + 3:idx + 6]).upper()
+							idx += 6
+
+							### section items
+							length_of_items = _ord(data[idx])
+							if length_of_items > 0:
+								curlen = 0
+								idx_items = idx + 1
+								while curlen < length_of_items:
+									### item description
+									(offset, item_description_text) = readEventData(data, idx_items, "extended_event_item_description")
+									idx_items += offset
+									curlen += offset
+
+									### item text
+									(offset, item_text) = readEventData(data, idx_items, "extended_event_item_text")
+									idx_items += offset
+									curlen += offset
+									extended_event_item = "\n" + item_description_text + ": " + item_text
+									addDescriptionToList(extended_event_item, extended_event_items, lang, ISO_639_language_code, prev2_ISO_639_language_code)									
+								idx += length_of_items
+							idx += 1
+
+							### section event text
+							(offset, extended_event_description) = readEventData(data, idx, "extended_event")							
+							if len(extended_event_description) > 0:
+								addDescriptionToList(extended_event_description, extended_event_descriptors, lang, ISO_639_language_code, prev2_ISO_639_language_code)
+
 							prev2_ISO_639_language_code = ISO_639_language_code
 						elif rec == 0x50:
 							component_descriptor.append(data[pos + 8:pos + length])
@@ -425,104 +441,45 @@ class EitList():
 							pass
 						pos += length
 
-					if name_event_descriptor:
-						name_event_descriptor = "".join(name_event_descriptor)
-					else:
-						name_event_descriptor = ("".join(name_event_descriptor_multi)).strip()
+					name_event_descriptor = ""
+					short_event_descriptor = ""
+					extended_event_descriptor = ""
+					extended_event_item_descriptor = ""
 
-					if short_event_descriptor:
-						short_event_descriptor = "".join(short_event_descriptor)
+					if name_event_descriptors[0]:
+						name_event_descriptor = "".join(name_event_descriptors[0])
 					else:
-						short_event_descriptor = ("".join(short_event_descriptor_multi)).strip()
+						name_event_descriptor = ("".join(name_event_descriptors[1])).strip()
 
-					if extended_event_descriptor:
-						extended_event_descriptor = "".join(extended_event_descriptor)
+					if short_event_descriptors[0]:
+						short_event_descriptor = "".join(short_event_descriptors[0])
 					else:
-						extended_event_descriptor = ("".join(extended_event_descriptor_multi)).strip()
+						short_event_descriptor = ("".join(short_event_descriptors[1])).strip()
+
+					if extended_event_descriptors[0]:
+						extended_event_descriptor = "".join(extended_event_descriptors[0])
+					else:
+						extended_event_descriptor = ("".join(extended_event_descriptors[1])).strip()
+
+					if extended_event_items[0]:
+						extended_event_item_descriptor = "".join(extended_event_items[0])
+					elif extended_event_items[1]:
+						extended_event_item_descriptor = ("".join(extended_event_items[1])).strip()
+
+					if extended_event_item_descriptor:
+						extended_event_descriptor += "\n" + extended_event_item_descriptor
 
 					if not(extended_event_descriptor):
 						extended_event_descriptor = short_event_descriptor
-						extended_event_codepage = short_event_codepage
 
-					if name_event_descriptor:
-						try:
-							if name_event_codepage:
-								if name_event_codepage != 'utf-8':
-									if PY3: # TODO PY3 improve
-										name_event_descriptor = name_event_descriptor.encode("utf-8").decode(name_event_codepage)
-									else:
-										name_event_descriptor = name_event_descriptor.decode(name_event_codepage).encode("utf-8")
-								elif not PY3:
-									name_event_descriptor.decode('utf-8')
-							else: #FIXME PY3
-								name_event_descriptor = six.ensure_binary(name_event_descriptor)
-								encdata = chardet.detect(name_event_descriptor)
-								enc = encdata['encoding'].lower()
-								confidence = str(encdata['confidence'])
-								emcDebugOut("[META] Detected name_event encoding-type: " + enc + " (" + confidence + ")")
-								name_event_descriptor = six.ensure_str(name_event_descriptor, enc)
-#								if enc == "utf-8":
-#									name_event_descriptor.decode(enc)
-#								else:
-#									name_event_descriptor = name_event_descriptor.decode(enc).encode('utf-8')
-						except (UnicodeDecodeError, AttributeError) as e:
-							emcDebugOut("[META] Exception in readEitFile: " + str(e))
 					self.eit['name'] = name_event_descriptor
-
-					if short_event_descriptor:
-						try:
-							if short_event_codepage:
-								if short_event_codepage != 'utf-8':
-									if PY3: # TODO PY3 improve
-										short_event_descriptor = short_event_descriptor.encode("utf-8").decode(name_event_codepage)
-									else:
-										short_event_descriptor = short_event_descriptor.decode(short_event_codepage).encode("utf-8")
-								elif not PY3:
-									short_event_descriptor.decode('utf-8')
-							else: #FIXME PY3
-								short_event_descriptor = six.ensure_binary(short_event_descriptor)
-								encdata = chardet.detect(short_event_descriptor)
-								enc = encdata['encoding'].lower()
-								confidence = str(encdata['confidence'])
-								emcDebugOut("[META] Detected short_event encoding-type: " + enc + " (" + confidence + ")")
-								short_event_descriptor = six.ensure_str(short_event_descriptor, enc)
-#								if enc == "utf-8":
-#									short_event_descriptor.decode(enc)
-#								else:
-#									short_event_descriptor = short_event_descriptor.decode(enc).encode('utf-8')
-						except (UnicodeDecodeError, AttributeError) as e:
-							emcDebugOut("[META] Exception in readEitFile: " + str(e))
 					self.eit['short_description'] = short_event_descriptor
 
 					if extended_event_descriptor:
-						try:
-							if extended_event_codepage:
-								if extended_event_codepage != 'utf-8':
-									if PY3: # TODO PY3 improve
-										extended_event_descriptor = extended_event_descriptor.encode("utf-8").decode(name_event_codepage)
-									else:
-										extended_event_descriptor = extended_event_descriptor.decode(extended_event_codepage).encode("utf-8")
-								elif not PY3:
-									extended_event_descriptor.decode('utf-8')
-							else: #FIXME PY3
-								extended_event_descriptor = six.ensure_binary(extended_event_descriptor)
-								encdata = chardet.detect(extended_event_descriptor)
-								enc = encdata['encoding'].lower()
-								confidence = str(encdata['confidence'])
-								emcDebugOut("[META] Detected extended_event encoding-type: " + enc + " (" + confidence + ")")
-								extended_event_descriptor = six.ensure_str(extended_event_descriptor, enc)
-#								if enc == "utf-8":
-#									extended_event_descriptor.decode(enc)
-#								else:
-#									extended_event_descriptor = extended_event_descriptor.decode(enc).encode('utf-8')
-						except (UnicodeDecodeError, AttributeError) as e:
-							emcDebugOut("[META] Exception in readEitFile: " + str(e))
-
 						# This will fix EIT data of RTL group with missing line breaks in extended event description
 						import re
 						extended_event_descriptor = re.sub('((?:Moderat(?:ion:|or(?:in){0,1})|Vorsitz: |Jur(?:isten|y): |G(?:\xC3\xA4|a)st(?:e){0,1}: |Mit (?:Staatsanwalt|Richter(?:in){0,1}|den Schadenregulierern) |Julia Leisch).*?[a-z]+)(\'{0,1}[0-9A-Z\'])', r'\1\n\n\2', extended_event_descriptor)
 					self.eit['description'] = extended_event_descriptor
-
 				else:
 					# No date clear all
 					self.eit = {}

--- a/src/EitSupport.py
+++ b/src/EitSupport.py
@@ -32,8 +32,8 @@ from datetime import datetime
 from Components.config import config
 from Components.Language import language
 from .EMCTasker import emcDebugOut
+from .FreesatHuffmanDecoder import FreesatHuffmanDecoder
 from .IsoFileSupport import IsoSupport
-
 from .MetaSupport import getInfoFile
 
 
@@ -70,134 +70,11 @@ def language_iso639_2to3(alpha2):
 
 
 def _ord(val):
-	if six.PY3:
-		return val
-	else:
-		return ord(val)
+	return val if six.PY3 else ord(val)
 
 
-# Convert string to bytes without encoding
-def encode_binary(input):
-    output = bytes([ord(char) for char in input])
-    return output
-
-
-# Get encoding
-def getEventEncoding(data):
-	encoding = None
-	try:
-		if len(data) > 0:
-			byte1 = _ord(data[0])			
-			if byte1 == 0x01:
-				encoding = 'iso-8859-5'
-			elif byte1 == 0x02:
-				encoding = 'iso-8859-6'
-			elif byte1 == 0x03:
-				encoding = 'iso-8859-7'
-			elif byte1 == 0x04:
-				encoding = 'iso-8859-8'
-			elif byte1 == 0x05:
-				encoding = 'iso-8859-9'
-			elif byte1 == 0x06:
-				encoding = 'iso-8859-10'
-			elif byte1 == 0x07:
-				encoding = 'iso-8859-11'
-			elif byte1 == 0x09:
-				encoding = 'iso-8859-13'
-			elif byte1 == 0x0A:
-				encoding = 'iso-8859-14'
-			elif byte1 == 0x0B:
-				encoding = 'iso-8859-15'
-			elif byte1 == 0x15:
-				encoding = 'utf-8'
-			elif byte1 == 0x10 and len(data) > 2:
-				byte2 = _ord(data[1])
-				if byte2 == 0x00:
-					byte3 = _ord(data[2])
-					if byte3 == 0x01:
-						encoding = 'iso-8859-1'
-					elif byte3 == 0x02:
-						encoding = 'iso-8859-2'
-					elif byte3 == 0x03:
-						encoding = 'iso-8859-3'
-					elif byte3 == 0x04:
-						encoding = 'iso-8859-4'
-					elif byte3 == 0x05:
-						encoding = 'iso-8859-5'
-					elif byte3 == 0x06:
-						encoding = 'iso-8859-6'
-					elif byte3 == 0x07:
-						encoding = 'iso-8859-7'
-					elif byte3 == 0x08:
-						encoding = 'iso-8859-8'
-					elif byte3 == 0x09:
-						encoding = 'iso-8859-9'
-					elif byte3 == 0x0A:
-						encoding = 'iso-8859-10'
-					elif byte3 == 0x0B:
-						encoding = 'iso-8859-11'
-					elif byte3 == 0x0D:
-						encoding = 'iso-8859-13'
-					elif byte3 == 0x0E:
-						encoding = 'iso-8859-14'
-					elif byte3 == 0x0F:
-						encoding = 'iso-8859-15'			
-			elif byte1 >= 0x20 and byte1 <= 0xFF:
-				encoding = 'iso6937'
-			#elif byte1 >= 0x11 and byte <= 0x14 or byte1 == 0x1F:	### not supported now
-			#	encoding = None
-	except:
-		encoding = None
-	return encoding
-
-
-# Read event data and decode it
-def readEventData(data, index, name):
-	description = ""
-	length = _ord(data[index])
-	if length > 0:
-		encoding = getEventEncoding(data[index + 1:index + 4])
-		if encoding:
-			emcDebugOut("[META] Found " + name + " encoding-type: " + encoding)			
-		for i in list(range(index + 1, index + length + 1)):
-			try:
-				if _ord(data[i]) == 0x0A or _ord(data[i]) > 0x1F:
-					if six.PY3:
-						description += chr(data[i])
-					else:
-						description += data[i]
-			except IndexError as e:
-				emcDebugOut("[META] Exception in readEitFile: " + str(e))
-
-		if description:
-			try:
-				if encoding:
-					if encoding != 'iso6937':
-						if six.PY3:
-							description = encode_binary(description).decode(encoding)
-						elif encoding != 'utf-8':
-							description = description.decode(encoding).encode("utf-8")
-					elif not six.PY3:
-						description = description.decode('cp1252').encode("utf-8")
-				else:
-					description = six.ensure_binary(description)
-					encdata = chardet.detect(description)
-					enc = encdata['encoding'].lower()
-					confidence = str(encdata['confidence'])
-					emcDebugOut("[META] Detected " + name + " encoding-type: " + enc + " (" + confidence + ")")
-					description = six.ensure_str(description, enc)
-			except (UnicodeDecodeError, AttributeError) as e:
-				emcDebugOut("[META] Exception in readEitFile: " + str(e))
-	return length + 1, description
-
-
-def addDescriptionToList(description, descriptionList, pluginLanguage, eventLanguage, prevEventLanguage, newLine = True):
-	if eventLanguage == pluginLanguage:
-		descriptionList[0].append(description)
-	if (eventLanguage == prevEventLanguage) or (prevEventLanguage == "x"):
-		descriptionList[1].append(description)
-	else:
-		descriptionList[1].append("\n\n" if newLine else "  " + description)
+# Global variable for special decoders
+_decoders = {}
 
 
 # Eit File support class
@@ -259,6 +136,12 @@ class EitList():
 				return None
 		else:
 			return None
+
+	def __bytes2string(self, bytes):
+		result = ""
+		for b in bytes:
+			result += chr(b)
+		return result;
 
 	##############################################################################
 	## Get Functions
@@ -343,7 +226,8 @@ class EitList():
 				if data and 12 <= len(data):
 					# go through events
 					pos = 0
-					e = struct.unpack(">HHBBBBBBH", data[pos:pos + 12])
+					memdata = memoryview(data)
+					e = struct.unpack(">HHBBBBBBH", memdata[pos:pos + 12])
 					event_id = e[0]
 					date = parseMJD(e[1])                         # Y, M, D
 					time = unBCD(e[2]), unBCD(e[3]), unBCD(e[4])  # HH, MM, SS
@@ -379,22 +263,20 @@ class EitList():
 							break
 						length = _ord(data[pos + 1]) + 2
 						idx = pos
-						#if pos+length>=endpos:
-						#	break
 						if rec == 0x4D:
 							ISO_639_language_code = six.ensure_str(data[idx + 2:idx + 5]).upper()
 							idx += 5
 
 							### section name
-							(offset, name_event_description) = readEventData(data, idx, "name_event")
+							(offset, name_event_description) = self.__readEventData(memdata, idx, "name_event")
 							if offset > 1:
-								addDescriptionToList(name_event_description, name_event_descriptors, lang, ISO_639_language_code, prev1_ISO_639_language_code, False)
+								self.__addDescriptionToList(name_event_description, name_event_descriptors, lang, ISO_639_language_code, prev1_ISO_639_language_code, False)
 							idx += offset
-							
+
 							### section description
-							(offset, short_event_description) = readEventData(data, idx, "short_event")
+							(offset, short_event_description) = self.__readEventData(memdata, idx, "short_event")
 							if offset > 1:
-								addDescriptionToList(short_event_description, short_event_descriptors, lang, ISO_639_language_code, prev1_ISO_639_language_code)
+								self.__addDescriptionToList(short_event_description, short_event_descriptors, lang, ISO_639_language_code, prev1_ISO_639_language_code)
 
 							prev1_ISO_639_language_code = ISO_639_language_code							
 						elif rec == 0x4E:
@@ -408,23 +290,23 @@ class EitList():
 								idx_items = idx + 1
 								while curlen < length_of_items:
 									### item description
-									(offset, item_description_text) = readEventData(data, idx_items, "extended_event_item_description")
+									(offset, item_description_text) = self.__readEventData(memdata, idx_items, "extended_event_item_description")
 									idx_items += offset
 									curlen += offset
 
 									### item text
-									(offset, item_text) = readEventData(data, idx_items, "extended_event_item_text")
+									(offset, item_text) = self.__readEventData(memdata, idx_items, "extended_event_item_text")
 									idx_items += offset
 									curlen += offset
 									extended_event_item = "\n" + item_description_text + ": " + item_text
-									addDescriptionToList(extended_event_item, extended_event_items, lang, ISO_639_language_code, prev2_ISO_639_language_code)									
+									self.__addDescriptionToList(extended_event_item, extended_event_items, lang, ISO_639_language_code, prev2_ISO_639_language_code)									
 								idx += length_of_items
 							idx += 1
 
 							### section event text
-							(offset, extended_event_description) = readEventData(data, idx, "extended_event")							
+							(offset, extended_event_description) = self.__readEventData(memdata, idx, "extended_event")							
 							if offset > 1:
-								addDescriptionToList(extended_event_description, extended_event_descriptors, lang, ISO_639_language_code, prev2_ISO_639_language_code)
+								self.__addDescriptionToList(extended_event_description, extended_event_descriptors, lang, ISO_639_language_code, prev2_ISO_639_language_code)
 
 							prev2_ISO_639_language_code = ISO_639_language_code
 						elif rec == 0x50:
@@ -483,7 +365,172 @@ class EitList():
 				else:
 					# No date clear all
 					self.eit = {}
-
 		else:
 			# No path or no file clear all
 			self.eit = {}
+
+	# Read event data and decode it
+	def __readEventData(self, data, index, name):
+		description = ""
+		length = _ord(data[index])
+		if length > 0:
+			(encoding, binary) = self.__getEventEncoding(data[index + 1:index + 4])
+			if encoding:
+				emcDebugOut("[META] Found " + name + " encoding-type: " + encoding)
+			buffer = bytearray(b'\x00') * length
+			bufferLen = 0
+			for i in list(range(index + 1, index + length + 1)):
+				try:
+					byte = _ord(data[i])
+					if binary or byte == 0x0A or byte > 0x1F:
+						buffer[bufferLen] = byte
+						bufferLen += 1
+				except IndexError as e:
+					emcDebugOut("[META] Exception in readEitFile: " + str(e))
+
+			if bufferLen > 0:
+				try:
+					if (bufferLen) < len(buffer):
+						buffer = buffer[:bufferLen]
+						
+					if encoding:
+						if encoding == 'custom':
+							description = self.__decodeCustomEncoding(buffer)
+						elif encoding != 'default':
+							if six.PY3:
+								description = buffer.decode(encoding)
+							elif encoding != 'utf-8':
+								description = buffer.decode(encoding).encode('utf-8')
+							else:
+								description = str(buffer)
+						elif not six.PY3:
+							description = buffer.decode('iso-8859-1').encode('utf-8')
+						else:
+							description = self.__bytes2string(buffer)
+					else:
+						description = six.ensure_binary(self.__bytes2string(buffer))
+						encdata = chardet.detect(description)
+						enc = encdata['encoding']
+						if enc != None:
+							enc = encdata['encoding'].lower()
+							confidence = str(encdata['confidence'])
+							emcDebugOut("[META] Detected " + name + " encoding-type: " + enc + " (" + confidence + ")")
+							description = six.ensure_str(description, enc)
+						else:
+							emcDebugOut("[META] Encoding for " + name + " could not be detected")
+				except (UnicodeDecodeError, AttributeError) as e:
+					emcDebugOut("[META] Exception in readEitFile: " + str(e))
+		return length + 1, description
+
+	# Get encoding
+	def __getEventEncoding(self, data):
+		encoding = None
+		binary = False
+		try:
+			if len(data) > 0:
+				byte1 = _ord(data[0])			
+				if byte1 == 0x01:
+					encoding = 'iso-8859-5'
+				elif byte1 == 0x02:
+					encoding = 'iso-8859-6'
+				elif byte1 == 0x03:
+					encoding = 'iso-8859-7'
+				elif byte1 == 0x04:
+					encoding = 'iso-8859-8'
+				elif byte1 == 0x05:
+					encoding = 'iso-8859-9'
+				elif byte1 == 0x06:
+					encoding = 'iso-8859-10'
+				elif byte1 == 0x07:
+					encoding = 'iso-8859-11'
+				elif byte1 == 0x09:
+					encoding = 'iso-8859-13'
+				elif byte1 == 0x0A:
+					encoding = 'iso-8859-14'
+				elif byte1 == 0x0B:
+					encoding = 'iso-8859-15'
+				elif byte1 == 0x15:
+					encoding = 'utf-8'
+				elif byte1 == 0x10 and len(data) > 2:
+					byte2 = _ord(data[1])
+					if byte2 == 0x00:
+						byte3 = _ord(data[2])
+						if byte3 == 0x01:
+							encoding = 'iso-8859-1'
+						elif byte3 == 0x02:
+							encoding = 'iso-8859-2'
+						elif byte3 == 0x03:
+							encoding = 'iso-8859-3'
+						elif byte3 == 0x04:
+							encoding = 'iso-8859-4'
+						elif byte3 == 0x05:
+							encoding = 'iso-8859-5'
+						elif byte3 == 0x06:
+							encoding = 'iso-8859-6'
+						elif byte3 == 0x07:
+							encoding = 'iso-8859-7'
+						elif byte3 == 0x08:
+							encoding = 'iso-8859-8'
+						elif byte3 == 0x09:
+							encoding = 'iso-8859-9'
+						elif byte3 == 0x0A:
+							encoding = 'iso-8859-10'
+						elif byte3 == 0x0B:
+							encoding = 'iso-8859-11'
+						elif byte3 == 0x0D:
+							encoding = 'iso-8859-13'
+						elif byte3 == 0x0E:
+							encoding = 'iso-8859-14'
+						elif byte3 == 0x0F:
+							encoding = 'iso-8859-15'
+				#elif byte1 in { 0x11, 0x12, 0x13, 0x14 }:	### not supported now
+				#	encoding = None							
+				elif byte1 == 0x1F:
+					encoding = 'custom'
+					binary = True
+				elif byte1 >= 0x20 and byte1 <= 0xFF:
+					encoding = 'default'
+		except:
+			encoding = None
+		return (encoding, binary)
+
+	def __addDescriptionToList(self, description, descriptionList, pluginLanguage, eventLanguage, prevEventLanguage, newLine = True):
+		if eventLanguage == pluginLanguage:
+			descriptionList[0].append(description)
+		if (eventLanguage == prevEventLanguage) or (prevEventLanguage == "x"):
+			descriptionList[1].append(description)
+		else:
+			descriptionList[1].append("\n\n" if newLine else "  " + description)
+ 
+	def __decodeCustomEncoding(self, data):
+		global _decoders
+		result = ""
+		decoderName = None
+		
+		if len(data) > 1:
+			if data[0] == 0x1F:
+				if data[1] in { 0x01, 0x02 }:
+					decoderName = 'freesat-huffman'					
+		if decoderName:
+			try:
+				decoder = _decoders.get(decoderName) # get instance if already exists
+				if not decoder:
+					decoder = self.__decoderFactory(decoderName)
+					if decoder:
+						_decoders[decoderName] = decoder # add new instance 
+				if decoder:
+					result = decoder.decode(data)
+				else:
+					emcDebugOut("[META] Missing decoder for encoding-type: " + decoderName)
+			except Exception as e:
+				emcDebugOut("[META] Exception on decodeCustomEncoding: " + str(e))
+		else:
+			emcDebugOut("[META] Unsupported custom encoding")
+		return result
+
+	# Initialize a custom decoder (ready for further encodings)
+	def __decoderFactory(self, decoderName):
+		decoder = None
+		if decoderName == 'freesat-huffman':
+			decoder = FreesatHuffmanDecoder()
+		return decoder

--- a/src/EitSupport.py
+++ b/src/EitSupport.py
@@ -144,7 +144,7 @@ def getEventEncoding(data):
 						encoding = 'iso-8859-15'			
 			elif byte1 >= 0x20 and byte1 <= 0xFF:
 				encoding = 'iso6937'
-			#elif byte1 >= 0x11 and byte <= 0x14:	### not supported now
+			#elif byte1 >= 0x11 and byte <= 0x14 or byte1 == 0x1F:	### not supported now
 			#	encoding = None
 	except:
 		encoding = None
@@ -180,7 +180,7 @@ def readEventData(data, index, name):
 					elif not six.PY3:
 						description = description.decode('cp1252').encode("utf-8")
 				else:
-					description = encode_binary(description)
+					description = six.ensure_binary(description)
 					encdata = chardet.detect(description)
 					enc = encdata['encoding'].lower()
 					confidence = str(encdata['confidence'])

--- a/src/EitSupport.py
+++ b/src/EitSupport.py
@@ -387,13 +387,13 @@ class EitList():
 
 							### section name
 							(offset, name_event_description) = readEventData(data, idx, "name_event")
-							if offset > 0:
+							if offset > 1:
 								addDescriptionToList(name_event_description, name_event_descriptors, lang, ISO_639_language_code, prev1_ISO_639_language_code, False)
 							idx += offset
 							
 							### section description
 							(offset, short_event_description) = readEventData(data, idx, "short_event")
-							if offset > 0:
+							if offset > 1:
 								addDescriptionToList(short_event_description, short_event_descriptors, lang, ISO_639_language_code, prev1_ISO_639_language_code)
 
 							prev1_ISO_639_language_code = ISO_639_language_code							
@@ -423,7 +423,7 @@ class EitList():
 
 							### section event text
 							(offset, extended_event_description) = readEventData(data, idx, "extended_event")							
-							if len(extended_event_description) > 0:
+							if offset > 1:
 								addDescriptionToList(extended_event_description, extended_event_descriptors, lang, ISO_639_language_code, prev2_ISO_639_language_code)
 
 							prev2_ISO_639_language_code = ISO_639_language_code

--- a/src/FreesatHuffmanDecoder.py
+++ b/src/FreesatHuffmanDecoder.py
@@ -1,0 +1,182 @@
+#!/usr/bin/python
+# encoding: utf-8
+#
+# FreesatHuffmanDecoder
+# Copyright (C) 2022 pjsharp
+#
+# In case of reuse of this source code please do not remove this copyright.
+#
+#	This program is free software: you can redistribute it and/or modify
+#	it under the terms of the GNU General Public License as published by
+#	the Free Software Foundation, either version 3 of the License, or
+#	(at your option) any later version.
+#
+#	This program is distributed in the hope that it will be useful,
+#	but WITHOUT ANY WARRANTY; without even the implied warranty of
+#	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#	GNU General Public License for more details.
+#
+#	For more information on the GNU General Public License see:
+#	<http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import
+from enigma import eEnv
+from os.path import isabs
+import re
+
+# Global constants
+START = 0x00
+STOP = 0x00
+ESCAPE = 0x01
+
+
+# Support for freeSat huffman decoding
+class FreesatHuffmanDecoder():
+
+	coding_tables = [
+		['enigma2/freesat.t1', []],
+		['enigma2/freesat.t2', []]
+		]
+
+	def __init__(self, initializeTables = False):
+		if initializeTables:
+			for id in range(len(self.coding_tables)):
+				self.__getCodingTable(id)
+		return
+
+	def __getCodingTable(self, id):
+		result = None
+
+		if id > 0 and id <= len(self.coding_tables):
+			coding_table = self.coding_tables[id - 1]
+			if coding_table[1]:
+				result = coding_table[1]
+			else:
+				coding_table[1] = [{} for i in range(256)]
+				try:
+					with open(self.__getTableName(coding_table[0]), 'r') as fp:
+						pattern = re.compile('^(?:(?P<fromctrl>START|STOP|ESCAPE)|(?:0x(?P<fromhex>[0-9a-fA-F]{2}))|(?P<fromchar>.))\:(?P<binvalue>[01]+)\:(?:(?P<toctrl>STOP|ESCAPE)|(?:0x(?P<tohex>[0-9a-fA-F]{2}))|(?P<tochar>.))')
+						line = fp.readline()
+						while line:
+							try:
+								m = pattern.match(line)
+								if m:
+									fromchar = None
+									if m.group("fromchar"):
+										fromchar = ord(m.group("fromchar"))
+									elif m.group("fromhex"):
+										fromchar = int(m.group("fromhex"), base=16)
+									elif m.group("fromctrl"):
+										fromchar = START if m.group("fromctrl") == "START" else None
+
+									if fromchar == None:
+										continue
+										
+									binvalue = m.group("binvalue")
+									
+									if binvalue in coding_table[1][fromchar]:
+										continue
+										
+									tochar = ''
+									if m.group("tochar"):
+										tochar = ord(m.group("tochar"))
+									elif m.group("tohex"):
+										tochar = int(m.group("tohex"), base=16)
+									elif m.group("toctrl"):
+										tochar = ESCAPE if m.group("toctrl") == "ESCAPE" else STOP
+									coding_table[1][fromchar][binvalue] = tochar
+							finally:
+								line = fp.readline()
+				except Exception as e:
+					coding_table[1] = None
+					raise
+			result = coding_table[1]
+		return result
+
+	def __findNextChar(self, reader, table, lastchar):
+		nextchar = None
+		cdict = table[lastchar]
+		bits = ""
+		run = 1
+		while run:
+			c = reader.readBit()
+			if c == None:
+				run = 0
+				break
+			bits += str(c)
+			nextchar = cdict.get(bits)
+			if nextchar != None:
+				break;
+		return nextchar
+
+	def __getTableName(self, name):
+		return name if isabs(name) else eEnv.resolve("${datadir}" + "/" + name)
+
+	def decode(self, data):
+		result = ""
+
+		if data == None or len(data) <= 2 or data[0] != 0x1F or (data[1] != 0x01 and data[1] != 0x02):
+			return result
+
+		table = self.__getCodingTable(data[1])
+		if table == None:
+			raise Exception("Coding table could not be loaded")
+			
+		run = 1
+		lastchar = 0
+		reader = self.__BinaryReader(data[2:])
+		
+		while run:
+			if lastchar == ESCAPE:
+				nextchar = reader.readByte()
+				if nextchar == None:
+					break
+				if (nextchar & 0x80) == 0:
+					lastchar = nextchar
+				if nextchar != STOP and nextchar != ESCAPE:
+					result += chr(nextchar)
+			else:
+				nextchar = self.__findNextChar(reader, table, lastchar)
+				if nextchar == None:
+					break
+				if nextchar != STOP and nextchar != ESCAPE:
+					result += chr(nextchar)
+				lastchar = nextchar
+				
+			if lastchar == STOP:
+				run = 0
+		return result
+
+	# Helper class for binary reading
+	class __BinaryReader(object):
+
+		def __init__(self, data):
+			self.data = data		
+			self.byteidx = 0 if len(data) > 0 else -1
+			self.bitidx = 0
+
+		def readBit(self):
+			result = None
+			if self.byteidx >= 0:
+				byte = self.data[self.byteidx]
+				value = byte & (1 << (7 - self.bitidx))
+				self.bitidx += 1
+				if self.bitidx % 8 == 0:
+					if self.byteidx + 1 < len(self.data):
+						self.byteidx += 1
+						self.bitidx = 0
+					else:
+						self.byteidx = -1
+				result = 1 if value > 0 else 0
+			return result
+
+		def readByte(self):
+			result = 0
+			for i in range(8):
+				b = self.readBit()
+				if b != None:
+					result |= (b << (7 - i))
+				else:
+					result = None
+					break;
+			return result


### PR DESCRIPTION
Changes:

* encodings iso-8859-[1..4] and freesat huffman are now also supported
* fix for incorrect parsing and encoding/decoding of some event items
* repetitive calls have been encapsulated into the methods