### PR TITLE
Remove un-needed line

### DIFF
--- a/src/EnhancedMovieCenter.py
+++ b/src/EnhancedMovieCenter.py
@@ -300,9 +300,6 @@ class EnhancedMovieCenterMenu(ConfigListScreenExt, Screen):
 		self["config"].selectionChanged = selectionChanged
 		self["config"].onSelectionChanged.append(self.updateHelp)
 
-		#Todo Remove if there is another solution, maybe thinkabout xml
-		config.EMC.movie_finished_clean.addNotifier(self.changedEntry, initial_call=False, immediate_feedback=True)
-
 	def defineConfig(self):
 
 		self.section = 400 * "¯"


### PR DESCRIPTION
In openbh this line caused the setup screen to be missing, if it was opened twice without restarting E2 inbetween.